### PR TITLE
docs: remove old functions related to circular props

### DIFF
--- a/docs/v1.md
+++ b/docs/v1.md
@@ -212,7 +212,6 @@
 - additionalProperties : `boolean | Schema`
 - allOf : `Schema[]`
 - anyOf : `Schema[]`
-- circularProps : `string[]`
 - const : `any`
 - contains : `Schema`
 - contentEncoding : `string` | `undefined`
@@ -231,12 +230,12 @@
 - exclusiveMaximum() : `number` | `undefined`
 - exclusiveMinimum : `number` | `undefined`
 - format : `string` | `undefined`
-- hasCircularProps : `boolean`
 - hasExtension(name) : `boolean`
   - name : `string`
 - if : `Schema`
 - isCircular : `boolean`
 - items : `Schema | Schema[]`
+- getCircularSchema : `Schema`
 - maximum() : `number` | `undefined`
 - maxItems : `number` | `undefined`
 - maxLength : `number` | `undefined`

--- a/docs/v1.md
+++ b/docs/v1.md
@@ -230,7 +230,7 @@
 - exclusiveMaximum() : `number` | `undefined`
 - exclusiveMinimum : `number` | `undefined`
 - format : `string` | `undefined`
-- getCircularSchema : `Schema`
+- circularSchema : `Schema`
 - hasExtension(name) : `boolean`
   - name : `string`
 - isBooleanSchema: `boolean`

--- a/docs/v1.md
+++ b/docs/v1.md
@@ -230,12 +230,13 @@
 - exclusiveMaximum() : `number` | `undefined`
 - exclusiveMinimum : `number` | `undefined`
 - format : `string` | `undefined`
+- getCircularSchema : `Schema`
 - hasExtension(name) : `boolean`
   - name : `string`
+- isBooleanSchema: `boolean`
 - if : `Schema`
 - isCircular : `boolean`
 - items : `Schema | Schema[]`
-- getCircularSchema : `Schema`
 - maximum() : `number` | `undefined`
 - maxItems : `number` | `undefined`
 - maxLength : `number` | `undefined`


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- remove old functions related to circular props: `hasCircularProps` and `circularProps` - more info here -> https://github.com/asyncapi/parser-js/pull/391#discussion_r737622836
- add missed `isBooleanSchema` function
- add new `getCircularSchema` function 