### PR TITLE
ci: add GH action workflow for releasing to GH

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,4 +26,4 @@ jobs:
           GIT_AUTHOR_EMAIL: info@asyncapi.io
           GIT_COMMITTER_NAME: asyncapi-bot
           GIT_COMMITTER_EMAIL: info@asyncapi.io
-        run: npx semantic-release
+        run: npx semantic-release@19.0.4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           node-version: 14
       - name: Add plugin for conventional commits
-        run: npm install conventional-changelog-conventionalcommits
+        run: npm install conventional-changelog-conventionalcommits@5.0.0
         working-directory: ./.github/workflows
       - name: Release to GitHub
         working-directory: ./.github/workflows

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
       - name: Setup Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 14
       - name: Add plugin for conventional commits

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+jobs: 
+  release:
+    name: 'Release to GitHub'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
+      - name: Add plugin for conventional commits
+        run: npm install conventional-changelog-conventionalcommits
+        working-directory: ./.github/workflows
+      - name: Release to GitHub
+        working-directory: ./.github/workflows
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GIT_AUTHOR_NAME: asyncapi-bot
+          GIT_AUTHOR_EMAIL: info@asyncapi.io
+          GIT_COMMITTER_NAME: asyncapi-bot
+          GIT_COMMITTER_EMAIL: info@asyncapi.io
+        run: npx semantic-release

--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,9 @@
+---
+branches:
+- master
+plugins:
+- - "@semantic-release/commit-analyzer"
+  - preset: conventionalcommits
+- - "@semantic-release/release-notes-generator"
+  - preset: conventionalcommits
+- - "@semantic-release/github"

--- a/.releaserc
+++ b/.releaserc
@@ -1,9 +1,21 @@
 ---
 branches:
 - master
+# by default release workflow reacts on push not only to master. 
+#This is why out of the box sematic release is configured for all these branches
+- name: next-spec
+  prerelease: true
+- name: next-major
+  prerelease: true
+- name: next-major-spec
+  prerelease: true
+- name: beta
+  prerelease: true
+- name: alpha
+  prerelease: true
 plugins:
 - - "@semantic-release/commit-analyzer"
   - preset: conventionalcommits
 - - "@semantic-release/release-notes-generator"
   - preset: conventionalcommits
-- - "@semantic-release/github"
+- "@semantic-release/github"


### PR DESCRIPTION
**Description**

This PR adds a GH action to automatically release to GH following conventional commits.

**Related issue(s)**
https://github.com/asyncapi/parser-api/pull/94#issuecomment-1519849250

cc @derberg @14richa