### PR TITLE
feat!: add support for multi-format schemas

### DIFF
--- a/docs/v1.md
+++ b/docs/v1.md
@@ -211,7 +211,8 @@
 
 ## MessageTrait
 - id(): `string`
-- schemaFormat(): `string`
+- schemaFormat(): `string` | `undefined`
+- hasSchemaFormat(): `boolean`
 - hasMessageId(): `boolean`
 - messageId(): `string` | `undefined`
 - hasCorrelationId(): `boolean`
@@ -338,7 +339,7 @@
 - examples(): `any[]` | `undefined`
 - exclusiveMaximum(): `number` | `undefined`
 - exclusiveMinimum(): `number` | `undefined`
-- format(): `string` | `undefined`
+- format(): `string`
 - id(): `string`
 - isBooleanSchema(): `boolean`
 - if(): `Schema` | `undefined`


### PR DESCRIPTION
**Description**

Required for and implemented in https://github.com/asyncapi/parser-js/pull/814.

Additionally, schema.format() will always return a value. Will return the default format if undefined. This is BC.

Alternative for the BC is to keep the previous interface `format(): string | undefined` but from now on implementations will never return undefined. 
As this Parser-API is in early stages, I think we could release a major version with such a change and avoid carrying this in the future. WDYT?

cc @fmvilas 

**Related issue(s)**
- https://github.com/asyncapi/parser-js/pull/814
- https://github.com/asyncapi/spec/issues/622