### PR TITLE
feat!: remove messageId() from the Message and MessageTrait objects

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,4 +1,4 @@
-# AsyncAPI Parser API v2.0.0
+# AsyncAPI Parser API v3.0.0
 
 ## AsyncAPIDocument
 - version(): `string`

--- a/docs/api.md
+++ b/docs/api.md
@@ -170,7 +170,6 @@
 - hasSchemaFormat(): `boolean`
 - schemaFormat(): `string` | `undefined`
 - hasMessageId(): `boolean`
-- messageId(): `string` | `undefined`
 - hasCorrelationId(): `boolean`
 - correlationId(): `CorrelationId` | `undefined`
 - hasContentType(): `boolean`
@@ -229,7 +228,6 @@
 - hasSchemaFormat(): `boolean`
 - schemaFormat(): `string` | `undefined`
 - hasMessageId(): `boolean`
-- messageId(): `string` | `undefined`
 - hasCorrelationId(): `boolean`
 - correlationId(): `CorrelationId` | `undefined`
 - hasContentType(): `boolean`


### PR DESCRIPTION
**Description**

> **Warning:** this would trigger a new major version.

It removes `messageId()` from the Message and MessageTrait objects. We already have `id()` so it doesn't make sense to have it there anymore.

If this changes is accepted and parser-api@3 is released, I'll update the table at https://github.com/asyncapi/parser-js#api-documentation.

**Related issue(s)**
https://github.com/asyncapi/spec/issues/978