### PR TITLE
docs: adding migration guides

### DIFF
--- a/docs/migration/migrating-to-v3.md
+++ b/docs/migration/migrating-to-v3.md
@@ -52,13 +52,9 @@ In v2, the return type of `schemaFormat()` in `Message` and `MessageTrait` objec
 # AsyncAPI Parser API v2.0.0
 ...
 ## Message
-- id(): `string`
-- hasSchemaFormat(): `boolean`
 - schemaFormat(): `string`
 ...
 ## MessageTrait
-- id(): `string`
-- hasSchemaFormat(): `boolean`
 - schemaFormat(): `string`
 ```
 
@@ -68,12 +64,8 @@ In v3, the return type has been changed to `string | undefined`, emphasizing tha
 # AsyncAPI Parser API v3.0.0
 ...
 ## Message
-- id(): `string`
-- hasSchemaFormat(): `boolean`
 - schemaFormat(): `string` | `undefined`
 ...
 ## MessageTrait
-- id(): `string`
-- hasSchemaFormat(): `boolean`
 - schemaFormat(): `string` | `undefined`
 ```

--- a/docs/migration/migrating-to-v3.md
+++ b/docs/migration/migrating-to-v3.md
@@ -1,0 +1,79 @@
+---
+title: "Migrating to v3"
+---
+
+To provide as smooth a transition as possible, this document shows the breaking changes between AsyncAPI Parser API v2.0.0 and v3.0.0 in an interactive manner.
+
+The changes from v2 to v3 are reflected in `Message` and `MessageTrait` objects.
+
+
+## Replaced `messageId` with `id`
+
+Since `id()` already represents that the message has an ID, `messageId()` is redundent in terms of the purpose.
+
+```md
+# AsyncAPI Parser API v2.0.0
+...
+## Message
+- id(): `string`
+- hasMessageId(): `boolean`
+- messageId(): `string` | `undefined`
+...
+## MessageTrait
+- id(): `string`
+- hasMessageId(): `boolean`
+- messageId(): `string` | `undefined`
+```
+
+```md
+# AsyncAPI Parser API v3.0.0
+...
+## Message
+- id(): `string`
+- hasMessageId(): `boolean`
+...
+## MessageTrait
+- id(): `string`
+- hasMessageId(): `boolean`
+```
+
+
+------------------------------
+
+
+
+## Changed Return Types for  `schemaFormat`
+
+In v2, the return type of `schemaFormat()` in `Message` and `MessageTrait` objects is only defined as `string`. 
+
+
+
+```md
+# AsyncAPI Parser API v2.0.0
+...
+## Message
+- id(): `string`
+- hasSchemaFormat(): `boolean`
+- schemaFormat(): `string`
+...
+## MessageTrait
+- id(): `string`
+- hasSchemaFormat(): `boolean`
+- schemaFormat(): `string`
+```
+
+In v3, the return type has been changed to `string | undefined`, emphasizing that the payload of a message is optional, so it can be undefined as well as be defined as a string. 
+
+```md
+# AsyncAPI Parser API v3.0.0
+...
+## Message
+- id(): `string`
+- hasSchemaFormat(): `boolean`
+- schemaFormat(): `string` | `undefined`
+...
+## MessageTrait
+- id(): `string`
+- hasSchemaFormat(): `boolean`
+- schemaFormat(): `string` | `undefined`
+```


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
- Add migration guide docs in a seperate file `/migration/migrating-to-v3.md` under the `/docs` section. I used the same format as the [main migration file](https://github.com/asyncapi/website/blob/d3d4af63e0506f83a2b5087bbbabbb31a34d4b8a/pages/docs/migration/migrating-to-v3.md) for Async API.
- Preview: 
<img width="998" alt="截屏2024-02-19 下午12 07 08" src="https://github.com/asyncapi/parser-api/assets/20860329/64df03bd-b5fb-499d-9ff2-ce05a9ea17f5">

**Related issue(s)**
Add migration guides #106

cc @jonaslagoni 
