### PR TITLE
docs: document Channels.filterByAddress

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -51,6 +51,7 @@
 - tags(): `Tags`
 - bindings(): `Bindings`
 - extensions(): `Extensions`
+- filterByAddress(address: string): Channels
 
 ## Channels
 - all(): `Channel[]`


### PR DESCRIPTION
<!--
Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Documents a new `filterByAddress(address: string)` helper on the Channels collection.

Currently, retrieving channels by address requires manually filtering:
`parsedAsyncAPI.channels().all().filter(...)`, which is verbose and less readable.
This helper provides a clearer and more discoverable API.

### Notes
- The method is documented as returning a collection (`Channels`), not a single channel,
  since multiple channels may share the same address.
- This PR only updates the API documentation.

### Related
- Implementation PR: asyncapi/parser-js#1119

